### PR TITLE
Feat/remove vote

### DIFF
--- a/src/domain/errors/VoteNotFoundError.ts
+++ b/src/domain/errors/VoteNotFoundError.ts
@@ -1,0 +1,6 @@
+export default class VoteNotFoundError extends Error {
+  constructor() {
+    super('Vote not found');
+    this.name = 'VoteNotFoundError';
+  }
+}

--- a/src/domain/interfaces/repositories/IVoteRepository.ts
+++ b/src/domain/interfaces/repositories/IVoteRepository.ts
@@ -6,4 +6,5 @@ export interface IVoteRepository {
   countVotesByPollOption(
     pollId: string,
   ): Promise<{ optionId: string; count: number }[]>;
+  delete(userId: string, pollId: string): Promise<void>;
 }

--- a/src/domain/use-cases/vote/remove.ts
+++ b/src/domain/use-cases/vote/remove.ts
@@ -1,0 +1,19 @@
+import VoteNotFoundError from '~/domain/errors/VoteNotFoundError';
+import { IVoteRepository } from '~/domain/interfaces/repositories/IVoteRepository';
+
+export default class RemoveVoteUseCase {
+  constructor(private readonly voteRepository: IVoteRepository) {}
+
+  async execute(userId: string, pollId: string): Promise<void> {
+    const existingVote = await this.voteRepository.findByUserAndPoll(
+      userId,
+      pollId,
+    );
+
+    if (!existingVote) {
+      throw new VoteNotFoundError();
+    }
+
+    await this.voteRepository.delete(userId, pollId);
+  }
+}

--- a/src/infra/databases/typeorm/repositories/vote.repository.ts
+++ b/src/infra/databases/typeorm/repositories/vote.repository.ts
@@ -53,4 +53,11 @@ export default class VoteRepository implements IVoteRepository {
       count: parseInt(r.count, 10),
     }));
   }
+
+  async delete(userId: string, pollId: string): Promise<void> {
+    await this.voteRepository.delete({
+      voterId: userId,
+      pollId: pollId,
+    });
+  }
 }

--- a/src/infra/nestjs/controllers/vote.controller.ts
+++ b/src/infra/nestjs/controllers/vote.controller.ts
@@ -1,10 +1,13 @@
 import {
   Controller,
   Patch,
+  Delete,
   Body,
   UseGuards,
   Request,
   Param,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -42,5 +45,25 @@ export default class VoteController {
     @Body() body: VoteCreateDTO,
   ): Promise<VoteResponseDTO> {
     return this.voteService.createVote(req.user.id, pollId, body as any);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Delete(':pollId/vote')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiParam({
+    name: 'pollId',
+    description: 'The ID of the poll to remove vote from',
+    type: 'string',
+  })
+  @ApiOkResponse({
+    description: 'Vote successfully removed',
+  })
+  @ApiCommonResponses({ unauthorized: true, forbidden: false })
+  async removeVote(
+    @Request() req,
+    @Param('pollId') pollId: string,
+  ): Promise<void> {
+    return this.voteService.removeVote(req.user.id, pollId);
   }
 }

--- a/tests/unit/use-cases/vote/remove-vote.spec.ts
+++ b/tests/unit/use-cases/vote/remove-vote.spec.ts
@@ -1,0 +1,143 @@
+import RemoveVoteUseCase from '../../../../src/domain/use-cases/vote/remove';
+import { IVoteRepository } from '../../../../src/domain/interfaces/repositories/IVoteRepository';
+import VoteNotFoundError from '../../../../src/domain/errors/VoteNotFoundError';
+import Votes from '../../../../src/domain/entities/Vote';
+import User from '../../../../src/domain/entities/User';
+import Poll from '../../../../src/domain/entities/Poll';
+import PollOption from '../../../../src/domain/entities/PollOption';
+
+describe('RemoveVoteUseCase', () => {
+  let removeVoteUseCase: RemoveVoteUseCase;
+  let voteRepository: jest.Mocked<IVoteRepository>;
+
+  beforeEach(() => {
+    voteRepository = {
+      create: jest.fn(),
+      findByUserAndPoll: jest.fn(),
+      countVotesByPollOption: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    removeVoteUseCase = new RemoveVoteUseCase(voteRepository);
+  });
+
+  describe('execute', () => {
+    const userId = '123e4567-e89b-12d3-a456-426614174000';
+    const pollId = '987e6543-e21b-34d5-b678-123456789abc';
+
+    const mockUser: User = {
+      id: userId,
+      name: 'John Doe',
+      email: 'john.doe@example.com',
+      password: 'hashedPassword123',
+      createdAt: new Date('2023-10-10T10:00:00.000Z'),
+      updatedAt: new Date('2023-10-10T10:00:00.000Z'),
+      lastLogin: undefined,
+    };
+
+    const mockPoll = new Poll({
+      id: pollId,
+      title: 'Favorite Programming Language',
+      description: 'Vote for your favorite language',
+      creator: mockUser,
+      createdAt: new Date('2023-10-10T10:00:00.000Z'),
+      updatedAt: new Date('2023-10-10T10:00:00.000Z'),
+    });
+
+    const mockOption = new PollOption({
+      id: 'option-123',
+      text: 'TypeScript',
+      poll: mockPoll,
+      createdAt: new Date('2023-10-10T10:00:00.000Z'),
+    });
+
+    const mockVote: Votes = {
+      voter: mockUser,
+      poll: mockPoll,
+      option: mockOption,
+      createdAt: new Date('2023-10-15T10:00:00.000Z'),
+      updatedAt: new Date('2023-10-15T10:00:00.000Z'),
+    };
+
+    it('should remove a vote successfully when vote exists', async () => {
+      voteRepository.findByUserAndPoll.mockResolvedValue(mockVote);
+      voteRepository.delete.mockResolvedValue(undefined);
+
+      await removeVoteUseCase.execute(userId, pollId);
+
+      expect(voteRepository.findByUserAndPoll).toHaveBeenCalledTimes(1);
+      expect(voteRepository.findByUserAndPoll).toHaveBeenCalledWith(
+        userId,
+        pollId,
+      );
+      expect(voteRepository.delete).toHaveBeenCalledTimes(1);
+      expect(voteRepository.delete).toHaveBeenCalledWith(userId, pollId);
+    });
+
+    it('should throw VoteNotFoundError when vote does not exist', async () => {
+      voteRepository.findByUserAndPoll.mockResolvedValue(null);
+
+      await expect(removeVoteUseCase.execute(userId, pollId)).rejects.toThrow(
+        VoteNotFoundError,
+      );
+
+      expect(voteRepository.findByUserAndPoll).toHaveBeenCalledTimes(1);
+      expect(voteRepository.findByUserAndPoll).toHaveBeenCalledWith(
+        userId,
+        pollId,
+      );
+      expect(voteRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('should throw VoteNotFoundError with correct message', async () => {
+      voteRepository.findByUserAndPoll.mockResolvedValue(null);
+
+      await expect(removeVoteUseCase.execute(userId, pollId)).rejects.toThrow(
+        'Vote not found',
+      );
+    });
+
+    it('should propagate repository errors from findByUserAndPoll', async () => {
+      const error = new Error('Database connection error');
+      voteRepository.findByUserAndPoll.mockRejectedValue(error);
+
+      await expect(removeVoteUseCase.execute(userId, pollId)).rejects.toThrow(
+        'Database connection error',
+      );
+
+      expect(voteRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('should propagate repository errors from delete', async () => {
+      const error = new Error('Failed to delete vote');
+      voteRepository.findByUserAndPoll.mockResolvedValue(mockVote);
+      voteRepository.delete.mockRejectedValue(error);
+
+      await expect(removeVoteUseCase.execute(userId, pollId)).rejects.toThrow(
+        'Failed to delete vote',
+      );
+
+      expect(voteRepository.findByUserAndPoll).toHaveBeenCalledTimes(1);
+      expect(voteRepository.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle different user and poll IDs', async () => {
+      const differentUserId = 'different-user-id';
+      const differentPollId = 'different-poll-id';
+
+      voteRepository.findByUserAndPoll.mockResolvedValue(mockVote);
+      voteRepository.delete.mockResolvedValue(undefined);
+
+      await removeVoteUseCase.execute(differentUserId, differentPollId);
+
+      expect(voteRepository.findByUserAndPoll).toHaveBeenCalledWith(
+        differentUserId,
+        differentPollId,
+      );
+      expect(voteRepository.delete).toHaveBeenCalledWith(
+        differentUserId,
+        differentPollId,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Rota da funcionalidade de `Remover Votos`.

### Justificativa:

Precisávamos de uma rota para um usuário cancelar o seu voto em uma votação. Para isso, subi a rota `/v1/polls/{pollId}/vote`, assim como seu teste unitário.

### Documentação:

Para a documentação, foi utilizado o `swagger`já configurado no projeto.

<img width="1432" height="168" alt="image" src="https://github.com/user-attachments/assets/8ab57e0f-9603-4df6-bf0a-5f115d3c8911" />

### Evidências dos Testes:
<img width="585" height="168" alt="image" src="https://github.com/user-attachments/assets/e5876b71-890d-4f58-ad8b-70ac2cf7fc19" />
